### PR TITLE
RCT-287: Adding homepage url for github pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "dot-theory-react",
   "private": true,
+  "homepage": "https://ct-aa.github.io/dotTheory---React",
   "version": "0.0.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
# Related Tickets
[RCT-287](https://codeandtheory.atlassian.net/browse/RCT-287)

# Description
Added homepage URL to be used for deployment on GitHub pages.

# Validation
N/A

# Risks
N/A